### PR TITLE
asciidoc: change require for api server

### DIFF
--- a/packages/asciidoc/index.js
+++ b/packages/asciidoc/index.js
@@ -1,5 +1,5 @@
 require('@babel/register');
-const { lint, lintPath } = require('./src/lint');
+const { lint, lintPath } = require('./src/lint/index'); // api server needs `/index`
 const { quotify, quotifyLine } = require('./src/quotify');
 const { splitLines, makeSplitLines, refMutate, refUnmutate } = require('./src/split');
 


### PR DESCRIPTION
only on the server, exports from /src/lint were undefined without adding the direct path to /index